### PR TITLE
Add Oracle backend deployment support

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+coverage
+.git
+.github
+.data
+*.log
+npm-debug.log*
+.env

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 3001
+
+CMD ["node", "dist/src/main.js"]

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -14,6 +14,6 @@ async function bootstrap() {
   app.useGlobalFilters(new HttpExceptionLoggingFilter());
   app.enableShutdownHooks();
 
-  await app.listen(process.env.PORT ?? 3001);
+  await app.listen(process.env.PORT ?? 3001, '0.0.0.0');
 }
 void bootstrap();


### PR DESCRIPTION
- Added backend Docker deployment files for running the Nest API on an Oracle Cloud VM.
- Added a production Dockerfile for building and running the backend in Docker.
- Added a .dockerignore file to keep the Docker build smaller and cleaner.
- Updated the Nest bootstrap server binding so the app listens on 0.0.0.0 for container and VM accessibility.
- Verified the backend runs successfully inside Docker on the Oracle VM.
- Verified the deployed backend responds successfully on the public health endpoint.
- Established the live backend base URL at http://161.118.254.213/api.
- Prepared the frontend to use the deployed backend through frontend environment variable configuration.