### PR TITLE
Add Oracle backend auto-deploy workflow

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -1,0 +1,80 @@
+name: Backend Auto Deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-deploy.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: backend-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-backend:
+    name: Deploy backend to Oracle VM
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check required secrets
+        env:
+          ORACLE_VM_HOST: ${{ secrets.ORACLE_VM_HOST }}
+          ORACLE_VM_USER: ${{ secrets.ORACLE_VM_USER }}
+          ORACLE_VM_SSH_KEY: ${{ secrets.ORACLE_VM_SSH_KEY }}
+          ORACLE_APP_DIR: ${{ secrets.ORACLE_APP_DIR }}
+        run: |
+          missing=0
+
+          for name in ORACLE_VM_HOST ORACLE_VM_USER ORACLE_VM_SSH_KEY ORACLE_APP_DIR; do
+            if [ -z "${!name}" ]; then
+              echo "Missing required secret: $name"
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.ORACLE_VM_HOST }}
+          username: ${{ secrets.ORACLE_VM_USER }}
+          key: ${{ secrets.ORACLE_VM_SSH_KEY }}
+          port: ${{ secrets.ORACLE_VM_PORT || '22' }}
+          script_stop: true
+          script: |
+            set -e
+
+            APP_DIR="${{ secrets.ORACLE_APP_DIR }}"
+            REPO_URL="https://github.com/${{ github.repository }}.git"
+
+            if [ ! -d "$APP_DIR/.git" ]; then
+              echo "Missing git repo at $APP_DIR"
+              exit 1
+            fi
+
+            cd "$APP_DIR"
+
+            git fetch "$REPO_URL" main
+            git checkout -B main FETCH_HEAD
+
+            cd backend
+
+            sudo docker build -t pinequest-backend .
+            sudo docker rm -f pinequest-backend || true
+            sudo docker run -d \
+              --name pinequest-backend \
+              --restart unless-stopped \
+              -p 80:3001 \
+              --env-file .env \
+              pinequest-backend
+
+            sleep 5
+            curl --fail --silent http://127.0.0.1/api/health > /tmp/pinequest-health.json
+            cat /tmp/pinequest-health.json


### PR DESCRIPTION
- Added a GitHub Actions workflow for automatic backend deployment to the Oracle Cloud VM.
- Configured the workflow to trigger automatically on pushes to main when backend-related files change.
- Added manual workflow trigger support so backend deployment can also be run on demand from GitHub Actions.
- Configured the deployment flow to connect to the Oracle VM over SSH using repository secrets.
- Updated the deployment process to pull the latest main branch on the VM before rebuilding.
- Rebuilds the backend Docker image automatically on the VM during deployment.
- Restarts the backend container automatically after a successful rebuild.
- Runs a backend health check after deployment to confirm the API starts successfully.
- Removes the need to manually SSH into the VM and run git pull, Docker rebuild, and container restart steps after backend merges.