### PR TITLE
Refine student exams UI and add avatar uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # PineQuest LMS
 
 This is PineQuest Part 2. A Learning Management System (LMS) project.
+
+To verify a deployed backend is correctly configured for shared avatar uploads, run:
+
+```powershell
+.\scripts\check_backend_health.ps1 -BaseUrl "https://your-backend-host"
+```

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -119,6 +119,36 @@
   * {
     @apply border-border outline-ring/50;
   }
+
+  :where(
+    a[href],
+    button:not(:disabled),
+    [role="button"]:not([aria-disabled="true"]),
+    summary,
+    label[for],
+    select:not(:disabled),
+    input[type="button"]:not(:disabled),
+    input[type="submit"]:not(:disabled),
+    input[type="reset"]:not(:disabled),
+    input[type="checkbox"]:not(:disabled),
+    input[type="radio"]:not(:disabled),
+    input[type="file"]:not(:disabled),
+    input[type="range"]:not(:disabled),
+    input[type="color"]:not(:disabled)
+  ) {
+    cursor: pointer;
+  }
+
+  :where(
+    button:disabled,
+    select:disabled,
+    input:disabled,
+    textarea:disabled,
+    [aria-disabled="true"]
+  ) {
+    cursor: default;
+  }
+
   body {
     @apply bg-background text-foreground;
   }

--- a/frontend/src/app/student/(authenticated)/dashboard/page.tsx
+++ b/frontend/src/app/student/(authenticated)/dashboard/page.tsx
@@ -17,7 +17,7 @@ const statCards = [
 ] as const
 
 export default function StudentDashboard() {
-  const { studentClass, studentName } = useStudentSession()
+  const { studentClass, studentId, studentName } = useStudentSession()
   const [allExams, setAllExams] = useState<Exam[]>(legacyExams)
 
   useEffect(() => {
@@ -79,7 +79,7 @@ export default function StudentDashboard() {
 
       <div className="grid min-h-0 flex-1 gap-5 xl:grid-cols-[900px_440px] xl:gap-[20px]">
         <div className="flex min-h-0 flex-col gap-[20px] xl:w-[900px]">
-          <StudentDashboardProfileCard studentName={studentName} />
+          <StudentDashboardProfileCard studentId={studentId} studentName={studentName} />
           <StudentDashboardScheduleCard exams={myExams} studentClass={studentClass} />
         </div>
 

--- a/frontend/src/app/student/(authenticated)/exams/[examId]/loading.tsx
+++ b/frontend/src/app/student/(authenticated)/exams/[examId]/loading.tsx
@@ -1,0 +1,15 @@
+export default function StudentExamDetailLoading() {
+  return (
+    <div className="flex min-h-[55vh] flex-col items-center justify-center gap-4 text-center">
+      <div className="rounded-full bg-sky-100 p-4 text-sky-700">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-current border-t-transparent" />
+      </div>
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold text-slate-900">Шалгалтын мэдээллийг ачаалж байна</h1>
+        <p className="max-w-md text-sm leading-6 text-slate-600">
+          Түр хүлээнэ үү. Таны сонгосон шалгалтын дэлгэрэнгүй мэдээллийг бэлдэж байна.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/student/(authenticated)/exams/[examId]/page.tsx
+++ b/frontend/src/app/student/(authenticated)/exams/[examId]/page.tsx
@@ -16,6 +16,22 @@ import {
 } from "@/lib/student-exam-time"
 import { getStudentExams } from "@/lib/student-exams"
 
+function StudentExamPageLoadingState() {
+  return (
+    <div className="flex min-h-[55vh] flex-col items-center justify-center gap-4 text-center">
+      <div className="rounded-full bg-sky-100 p-4 text-sky-700">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-current border-t-transparent" />
+      </div>
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold text-slate-900">Шалгалтын мэдээллийг ачаалж байна</h1>
+        <p className="max-w-md text-sm leading-6 text-slate-600">
+          Түр хүлээнэ үү. Таны сонгосон шалгалтын мэдээллийг backend-ээс авч байна.
+        </p>
+      </div>
+    </div>
+  )
+}
+
 export default function ExamDetailPage({ params }: { params: Promise<{ examId: string }> }) {
   const { examId } = use(params)
   const router = useRouter()
@@ -23,6 +39,7 @@ export default function ExamDetailPage({ params }: { params: Promise<{ examId: s
   const [countdown, setCountdown] = useState(0)
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [allExams, setAllExams] = useState<Exam[]>(legacyExams)
+  const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
     let isMounted = true
@@ -35,6 +52,9 @@ export default function ExamDetailPage({ params }: { params: Promise<{ examId: s
       } catch (loadError) {
         if (!isMounted) return
         console.warn("Failed to refresh exam details from the backend.", loadError)
+      } finally {
+        if (!isMounted) return
+        setIsLoading(false)
       }
     }
 
@@ -63,6 +83,10 @@ export default function ExamDetailPage({ params }: { params: Promise<{ examId: s
     const interval = setInterval(updateCountdown, 1000)
     return () => clearInterval(interval)
   }, [isTodayExam, schedule])
+
+  if (isLoading) {
+    return <StudentExamPageLoadingState />
+  }
 
   if (!exam) {
     return (

--- a/frontend/src/app/student/(authenticated)/exams/page.tsx
+++ b/frontend/src/app/student/(authenticated)/exams/page.tsx
@@ -1,75 +1,126 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
-import { StudentCompletedExamsSection } from "@/components/student/student-completed-exams-section"
-import { StudentTodayExamsSection, StudentUpcomingExamsSection } from "@/components/student/student-exams-sections"
-import { useStudentSession } from "@/hooks/use-student-session"
-import { examResults, exams as legacyExams, type Exam } from "@/lib/mock-data"
-import { getLocalDateString, getSecondsUntil } from "@/lib/student-exam-time"
-import { getStudentExams } from "@/lib/student-exams"
+import { Search } from "lucide-react"
+import {
+  FinishedExamCard,
+  UpcomingExamCard,
+} from "@/components/student/student-exams-page-cards"
+import { SegmentedTab } from "@/components/student/student-exams-page-controls"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useStudentExamsPage } from "@/hooks/use-student-exams-page"
 
 export default function StudentExamsPage() {
-  const { studentClass, studentId } = useStudentSession()
-  const [countdowns, setCountdowns] = useState<Record<string, number>>({})
-  const [allExams, setAllExams] = useState<Exam[]>(legacyExams)
-  const [isLoading, setIsLoading] = useState(true)
-
-  useEffect(() => {
-    let isMounted = true
-
-    const loadExams = async () => {
-      try {
-        const nextExams = await getStudentExams()
-        if (!isMounted) return
-        setAllExams(nextExams)
-      } catch (error) {
-        if (isMounted) console.warn("Failed to refresh student exams from the backend.", error)
-      } finally {
-        if (isMounted) setIsLoading(false)
-      }
-    }
-
-    void loadExams()
-    return () => {
-      isMounted = false
-    }
-  }, [studentClass, studentId])
-
-  const myExams = useMemo(() => allExams.filter((exam) =>
-    exam.scheduledClasses.some((schedule) => schedule.classId === studentClass),
-  ), [allExams, studentClass])
-  const scheduledExams = useMemo(() => myExams.filter((exam) => exam.status === "scheduled"), [myExams])
-  const today = getLocalDateString()
-  const todaysExams = useMemo(() => scheduledExams.filter((exam) =>
-    exam.scheduledClasses.some((schedule) => schedule.classId === studentClass && schedule.date === today),
-  ), [scheduledExams, studentClass, today])
-  const myResults = useMemo(() => examResults.filter((result) => result.studentId === studentId), [studentId])
-
-  useEffect(() => {
-    const updateCountdowns = () => {
-      const nextCountdowns: Record<string, number> = {}
-      todaysExams.forEach((exam) => {
-        const schedule = exam.scheduledClasses.find((entry) => entry.classId === studentClass)
-        if (schedule) nextCountdowns[exam.id] = getSecondsUntil(schedule.date, schedule.time)
-      })
-      setCountdowns(nextCountdowns)
-    }
-
-    updateCountdowns()
-    const interval = setInterval(updateCountdowns, 1000)
-    return () => clearInterval(interval)
-  }, [todaysExams, studentClass])
+  const {
+    activeTab,
+    categoryOptions,
+    filteredUpcomingExams,
+    finishedItems,
+    isLoading,
+    searchQuery,
+    selectedCategory,
+    setActiveTab,
+    setSearchQuery,
+    setSelectedCategory,
+    studentClass,
+  } = useStudentExamsPage()
+  const allCount = filteredUpcomingExams.length + finishedItems.length
+  const showUpcoming = activeTab === "all" || activeTab === "upcoming"
+  const showFinished = activeTab === "all" || activeTab === "finished"
 
   return (
-    <div className="space-y-6 px-[20px] pb-[20px] pt-[30px]">
-      <div>
-        <h1 className="text-2xl font-bold">Шалгалтууд</h1>
-        <p className="text-muted-foreground">Удахгүй болох болон дууссан шалгалтуудаа харах</p>
+    <div className="mx-auto w-full max-w-[1440px] px-6 pb-10 pt-5 xl:px-[155px]">
+      <div className="mx-auto flex w-full max-w-[1130px] flex-col gap-[30px]">
+        <div className="space-y-[7px]">
+          <h1 className="text-[24px] font-semibold leading-[29px] text-[#293138]">Шалгалтууд</h1>
+          <p className="text-[14px] leading-5 text-[#566069]">
+            Мэдлэгээ баталгаажуулах мөч ирлээ. Амжилт хүсье!
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-[10px]">
+          <div className="relative w-full max-w-[301px]">
+            <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-[#566069]" />
+            <Input
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder="Шалгалт хайх..."
+              className="h-11 rounded-full border border-[#E6F2FF] bg-[#F5FAFF] pl-10 text-[14px] font-medium text-[#566069] placeholder:text-[#566069]"
+            />
+          </div>
+
+          <Select value={selectedCategory} onValueChange={setSelectedCategory}>
+            <SelectTrigger className="h-12 min-w-[152px] rounded-full border border-[#E6F2FF] bg-[#66B2FF] px-4 text-[14px] font-medium text-[#F5FAFF] shadow-none [&_svg]:text-white [&_svg]:opacity-100">
+              <SelectValue placeholder="Бүх хичээл" />
+            </SelectTrigger>
+            <SelectContent>
+              {categoryOptions.map((category) => (
+                <SelectItem key={category} value={category}>
+                  {category === "all" ? "Бүх хичээл" : category}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <div className="flex w-[427px] items-center rounded-full border border-[#E6F2FF] bg-[#003366] p-2 shadow-[0px_9px_4px_rgba(201,201,201,0.01),0px_5px_3px_rgba(201,201,201,0.05),0px_2px_2px_rgba(201,201,201,0.09),0px_1px_1px_rgba(201,201,201,0.10)]">
+            <SegmentedTab active={activeTab === "all"} count={allCount} label="Бүгд" onClick={() => setActiveTab("all")} />
+            <SegmentedTab active={activeTab === "upcoming"} count={filteredUpcomingExams.length} label="Удахгүй" onClick={() => setActiveTab("upcoming")} />
+            <SegmentedTab active={activeTab === "finished"} count={finishedItems.length} label="Дууссан" onClick={() => setActiveTab("finished")} />
+          </div>
+        </div>
+
+        {isLoading ? <p className="text-sm text-[#566069]">Шалгалтуудыг ачаалж байна...</p> : null}
+
+        <div className="space-y-7">
+          {showUpcoming && filteredUpcomingExams.length > 0 ? (
+            <section className="space-y-5">
+              <div className="flex items-center gap-5">
+                <h2 className="text-[16px] font-semibold leading-[19px] text-[#293138]">Удахгүй болох шалгалтууд</h2>
+                <span className="flex h-[18px] min-w-[24px] items-center justify-center rounded-full bg-[#FFF3E0] px-2 text-[12px] font-bold leading-[1.2] text-[#FF9500]">
+                  {filteredUpcomingExams.length}
+                </span>
+              </div>
+              <div className="space-y-4">
+                {filteredUpcomingExams.map((exam) => (
+                  <UpcomingExamCard key={exam.id} exam={exam} href={`/student/exams/${exam.id}`} studentClass={studentClass} />
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          {showFinished && finishedItems.length > 0 ? (
+            <section className="space-y-5">
+              <div className="flex items-center gap-5">
+                <h2 className="text-[16px] font-semibold leading-[19px] text-[#293138]">Дууссан шалгалтууд</h2>
+                <span className="flex h-[18px] min-w-[24px] items-center justify-center rounded-full bg-[#E8F5E9] px-2 text-[12px] font-bold leading-[1.2] text-[#00C853]">
+                  {finishedItems.length}
+                </span>
+              </div>
+              <div className="space-y-4">
+                {finishedItems.map((item) => (
+                  <FinishedExamCard
+                    key={item.kind === "result" ? `${item.result.examId}-${item.result.studentId}` : `missed-${item.exam.id}`}
+                    item={item}
+                    studentClass={studentClass}
+                  />
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          {!isLoading && filteredUpcomingExams.length === 0 && finishedItems.length === 0 ? (
+            <div className="rounded-2xl border border-[#E6F2FF] bg-[#F9FAFB] px-6 py-10 text-center text-[#566069]">
+              Хайлтын нөхцөлд тохирох шалгалт олдсонгүй.
+            </div>
+          ) : null}
+        </div>
       </div>
-      {isLoading ? <p className="text-sm text-muted-foreground">Шалгалтуудыг ачаалж байна...</p> : null}
-      <StudentTodayExamsSection examsToday={todaysExams} studentClass={studentClass} countdowns={countdowns} />
-      <StudentUpcomingExamsSection upcomingExams={scheduledExams} todaysExams={todaysExams} studentClass={studentClass} />
-      <StudentCompletedExamsSection exams={allExams} results={myResults} />
     </div>
   )
 }

--- a/frontend/src/components/student/student-completed-exams-section.tsx
+++ b/frontend/src/components/student/student-completed-exams-section.tsx
@@ -5,19 +5,42 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import type { Exam, ExamResult } from '@/lib/mock-data'
+import { getScheduleEnd } from '@/lib/student-exam-time'
 import { isStudentExamReportAvailable } from '@/lib/student-exams'
 
 export function StudentCompletedExamsSection({
   exams,
+  missedExams,
   results,
+  studentClass,
 }: {
   exams: Exam[]
+  missedExams: Exam[]
   results: ExamResult[]
+  studentClass: string
 }) {
+  const sortedResults = [...results].sort((left, right) =>
+    right.submittedAt.localeCompare(left.submittedAt),
+  )
+
+  const sortedMissedExams = [...missedExams].sort((left, right) => {
+    const leftSchedule = left.scheduledClasses.find((entry) => entry.classId === studentClass)
+    const rightSchedule = right.scheduledClasses.find((entry) => entry.classId === studentClass)
+
+    const leftEndTime = leftSchedule
+      ? getScheduleEnd(leftSchedule.date, leftSchedule.time, left.duration).getTime()
+      : 0
+    const rightEndTime = rightSchedule
+      ? getScheduleEnd(rightSchedule.date, rightSchedule.time, right.duration).getTime()
+      : 0
+
+    return rightEndTime - leftEndTime
+  })
+
   return (
     <div>
       <h2 className="mb-3 text-lg font-semibold">Дууссан шалгалтууд</h2>
-      {results.length === 0 ? (
+      {sortedResults.length === 0 && sortedMissedExams.length === 0 ? (
         <Card>
           <CardContent className="py-6 text-center text-muted-foreground">
             Одоогоор дууссан шалгалт алга байна.
@@ -25,7 +48,7 @@ export function StudentCompletedExamsSection({
         </Card>
       ) : (
         <div className="space-y-3">
-          {results.map((result) => {
+          {sortedResults.map((result) => {
             const exam = exams.find((entry) => entry.id === result.examId)
             const percentage = Math.round((result.score / result.totalPoints) * 100)
             const variant =
@@ -37,14 +60,14 @@ export function StudentCompletedExamsSection({
                 <CardContent className="py-4">
                   <div className="flex items-center justify-between gap-4">
                     <div>
-                      <div className="font-medium">{exam?.title}</div>
+                      <div className="font-medium">{exam?.title ?? result.examId}</div>
                       <div className="text-sm text-muted-foreground">
                         Илгээсэн: {new Date(result.submittedAt).toLocaleString('mn-MN')}
                       </div>
                       <div className="mt-1 text-sm text-muted-foreground">
                         {isReportAvailable
-                          ? 'Дэлгэрэнгүй тайланг үзэх боломжтой'
-                          : 'Бүх анги шалгалтаа дууссаны дараа дэлгэрэнгүй тайлан нээгдэнэ'}
+                          ? 'Тайлангаа шалгах боломжтой'
+                          : 'Бүх анги шалгалтаа дууссаны дараа тайлан нээгдэнэ'}
                       </div>
                     </div>
                     <div className="text-right">
@@ -55,9 +78,39 @@ export function StudentCompletedExamsSection({
                       <div className="mt-3">
                         <Link href={`/student/reports/${result.examId}`}>
                           <Button size="sm" variant="outline">
-                            {isReportAvailable ? 'Тайлан үзэх' : 'Тайлан түгжээтэй'}
+                            {isReportAvailable ? 'Тайлан шалгах' : 'Тайлан түгжээтэй'}
                           </Button>
                         </Link>
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            )
+          })}
+
+          {sortedMissedExams.map((exam) => {
+            const schedule = exam.scheduledClasses.find((entry) => entry.classId === studentClass)
+
+            return (
+              <Card key={`missed-${exam.id}`} className="border-amber-200 bg-amber-50/40">
+                <CardContent className="py-4">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <div className="font-medium">{exam.title}</div>
+                      <div className="text-sm text-muted-foreground">
+                        {schedule ? `${schedule.date} ${schedule.time} (${exam.duration} мин)` : 'Хуваарь олдсонгүй'}
+                      </div>
+                      <div className="mt-1 text-sm text-amber-700">
+                        Та энэ шалгалтыг хоцорсон байна.
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <Badge variant="secondary" className="bg-amber-100 text-amber-800">
+                        Хоцорсон
+                      </Badge>
+                      <div className="mt-3 text-sm font-medium text-amber-700">
+                        Тайлан байхгүй
                       </div>
                     </div>
                   </div>

--- a/frontend/src/components/student/student-dashboard-profile-card.tsx
+++ b/frontend/src/components/student/student-dashboard-profile-card.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { type ChangeEvent, useState } from "react"
-import { Pencil } from "lucide-react"
+import { useRef, useState } from "react"
+import { Camera, Pencil } from "lucide-react"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
 import {
@@ -16,35 +16,11 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
-import { notifyStudentSessionChange } from "@/hooks/use-student-session"
-
-const STORAGE_KEYS = {
-  bio: "studentProfileBio",
-  image: "studentProfileImage",
-} as const
-
-const defaultBio = "Би ирээдүйд Дизайнер болно."
+import { useStudentDashboardProfile } from "@/hooks/use-student-dashboard-profile"
 
 type StudentDashboardProfileCardProps = {
+  studentId: string
   studentName: string
-}
-
-type ProfileState = {
-  name: string
-  bio: string
-  image: string
-}
-
-function getStoredProfile(studentName: string): ProfileState {
-  if (typeof window === "undefined") {
-    return { name: studentName, bio: defaultBio, image: "" }
-  }
-
-  return {
-    name: localStorage.getItem("studentName") || studentName,
-    bio: localStorage.getItem(STORAGE_KEYS.bio) || defaultBio,
-    image: localStorage.getItem(STORAGE_KEYS.image) || "",
-  }
 }
 
 function getInitials(name: string) {
@@ -57,56 +33,60 @@ function getInitials(name: string) {
 }
 
 export function StudentDashboardProfileCard({
+  studentId,
   studentName,
 }: StudentDashboardProfileCardProps) {
+  const imageInputRef = useRef<HTMLInputElement | null>(null)
   const [isOpen, setIsOpen] = useState(false)
-  const [profile, setProfile] = useState<ProfileState>(() => getStoredProfile(studentName))
-  const [draft, setDraft] = useState<ProfileState>(() => getStoredProfile(studentName))
+  const { defaultBio, draft, handleImageChange, isUploadingImage, persistProfile, profile, setDraft } =
+    useStudentDashboardProfile(studentId, studentName)
 
   const handleOpenChange = (open: boolean) => {
     if (open) setDraft(profile)
     setIsOpen(open)
   }
 
-  const handleImageChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    if (!file) return
-
-    const reader = new FileReader()
-    reader.onload = () => {
-      setDraft((current) => ({ ...current, image: String(reader.result || "") }))
-    }
-    reader.readAsDataURL(file)
-  }
-
   const handleSave = () => {
-    const nextProfile = {
+    persistProfile({
       name: draft.name.trim() || studentName,
       bio: draft.bio.trim() || defaultBio,
       image: draft.image,
-    }
-
-    localStorage.setItem("studentName", nextProfile.name)
-    localStorage.setItem(STORAGE_KEYS.bio, nextProfile.bio)
-    if (nextProfile.image) localStorage.setItem(STORAGE_KEYS.image, nextProfile.image)
-    else localStorage.removeItem(STORAGE_KEYS.image)
-
-    notifyStudentSessionChange()
-    setProfile(nextProfile)
+      imageUploadId: draft.imageUploadId,
+    })
     setIsOpen(false)
   }
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <div className="h-[102px] w-full rounded-[20px] border border-[#DCE8F3] bg-white p-[21px] shadow-[0_6px_24px_rgba(114,144,179,0.10)] xl:max-w-[900px]">
+        <input
+          ref={imageInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={(event) => void handleImageChange(event, true)}
+        />
+
         <div className="flex items-start justify-between gap-4">
           <div className="flex min-w-0 items-end gap-4">
-            <Avatar className="h-[58px] w-[58px] border border-[#E3EDF6] p-[1px] shadow-sm">
-              <AvatarImage src={profile.image} alt={profile.name} className="object-cover" />
-              <AvatarFallback className="bg-[#D8E9FF] text-lg font-bold text-[#4E87C7]">
-                {getInitials(profile.name)}
-              </AvatarFallback>
-            </Avatar>
+            <button
+              type="button"
+              onClick={() => imageInputRef.current?.click()}
+              className="group relative shrink-0 cursor-pointer rounded-full disabled:cursor-not-allowed disabled:opacity-70"
+              aria-label="Профайлын зураг сонгох"
+              disabled={isUploadingImage}
+            >
+              <Avatar className="h-[58px] w-[58px] border border-[#E3EDF6] p-[1px] shadow-sm transition group-hover:brightness-95">
+                <AvatarImage src={profile.image} alt={profile.name} className="object-cover" />
+                <AvatarFallback className="bg-[#D8E9FF] text-lg font-bold text-[#4E87C7]">
+                  {getInitials(profile.name)}
+                </AvatarFallback>
+              </Avatar>
+              <span className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-full bg-[#213047]/0 text-white transition group-hover:bg-[#213047]/35">
+                <Camera className="h-4 w-4 opacity-0 transition group-hover:opacity-100" />
+              </span>
+            </button>
+
             <div className="min-w-0">
               <p className="truncate font-sans text-[24px] font-semibold leading-[29px] text-[#2F3845]">
                 {profile.name}
@@ -114,13 +94,16 @@ export function StudentDashboardProfileCard({
               <p className="mt-1 truncate font-sans text-[14px] font-normal italic leading-[17px] text-[#667284]">
                 &quot;{profile.bio}&quot;
               </p>
+              {isUploadingImage ? (
+                <p className="mt-1 text-[12px] font-medium text-[#4A9DFF]">Зураг R2 рүү хадгалж байна...</p>
+              ) : null}
             </div>
           </div>
 
           <DialogTrigger asChild>
             <button
               type="button"
-              className="rounded-full p-2 text-[#7B8797] transition hover:bg-[#F4F8FC]"
+              className="cursor-pointer rounded-full p-2 text-[#7B8797] transition hover:bg-[#F4F8FC]"
               aria-label="Профайл засах"
             >
               <Pencil className="h-5 w-5" />
@@ -138,7 +121,14 @@ export function StudentDashboardProfileCard({
         <div className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="student-profile-image">Зураг</Label>
-            <Input id="student-profile-image" type="file" accept="image/*" onChange={handleImageChange} />
+            <Input
+              id="student-profile-image"
+              type="file"
+              accept="image/*"
+              onChange={(event) => void handleImageChange(event, true)}
+              disabled={isUploadingImage}
+              className="cursor-pointer"
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="student-profile-name">Нэр</Label>
@@ -146,6 +136,7 @@ export function StudentDashboardProfileCard({
               id="student-profile-name"
               value={draft.name}
               onChange={(event) => setDraft((current) => ({ ...current, name: event.target.value }))}
+              className="cursor-pointer"
             />
           </div>
           <div className="space-y-2">
@@ -154,15 +145,16 @@ export function StudentDashboardProfileCard({
               id="student-profile-bio"
               value={draft.bio}
               onChange={(event) => setDraft((current) => ({ ...current, bio: event.target.value }))}
+              className="cursor-pointer"
             />
           </div>
         </div>
 
         <DialogFooter>
-          <Button type="button" variant="outline" onClick={() => setIsOpen(false)}>
+          <Button type="button" variant="outline" onClick={() => setIsOpen(false)} className="cursor-pointer">
             Болих
           </Button>
-          <Button type="button" onClick={handleSave}>
+          <Button type="button" onClick={handleSave} disabled={isUploadingImage} className="cursor-pointer">
             Хадгалах
           </Button>
         </DialogFooter>

--- a/frontend/src/components/student/student-exams-page-cards.tsx
+++ b/frontend/src/components/student/student-exams-page-cards.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import Link from "next/link"
+import Image from "next/image"
+import { AlertCircle, Check, Clock3 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import type { Exam } from "@/lib/mock-data"
+import { isStudentExamReportAvailable } from "@/lib/student-exams"
+import {
+  type FinishedExamItem,
+  formatScheduleLabel,
+  getExamIcon,
+  getStudentSchedule,
+} from "@/components/student/student-exams-page-utils"
+
+export function UpcomingExamCard(props: {
+  exam: Exam
+  href: string
+  studentClass: string
+}) {
+  const { exam, href, studentClass } = props
+  const schedule = getStudentSchedule(exam, studentClass)
+
+  return (
+    <article className="flex items-center gap-3 rounded-2xl border border-[#E6F2FF] bg-[#F5FAFF] p-[17px] shadow-[0px_9px_4px_rgba(201,201,201,0.01),0px_5px_3px_rgba(201,201,201,0.05),0px_2px_2px_rgba(201,201,201,0.09),0px_1px_1px_rgba(201,201,201,0.10)]">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <div className="flex h-[60px] w-[60px] items-center justify-center rounded-2xl p-[10px]">
+          <Image src={getExamIcon(exam.title)} alt="" width={40} height={40} unoptimized className="h-10 w-10 object-contain" />
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-2">
+          <div className="flex flex-wrap items-center gap-5">
+            <h3 className="text-[18px] font-semibold leading-[22px] text-[#141A1F]">{exam.title}</h3>
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-[#FFF3E0] px-[9px] py-1 text-[12px] font-semibold leading-[1.2] text-[#FF9500]">
+              <span className="h-1.5 w-1.5 rounded-full bg-[#FF9500]" />
+              Удахгүй
+            </span>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3 text-[14px] font-medium leading-[17px] text-[#566069]">
+            <span className="inline-flex items-center gap-1">
+              <Clock3 className="h-[14px] w-[14px]" />
+              {exam.duration} мин
+            </span>
+            <span>{formatScheduleLabel(schedule?.date, schedule?.time)}</span>
+            <span>|</span>
+            <span>{exam.questions.length} асуулт</span>
+          </div>
+        </div>
+      </div>
+
+      <Link href={href}>
+        <Button variant="outline" className="h-[38px] min-w-[124px] rounded-xl border-[#E6F2FF] bg-[#E6F2FF] px-6 text-[12px] font-medium leading-[1.2] text-[#007FFF] shadow-[0px_9px_4px_rgba(201,201,201,0.01),0px_5px_3px_rgba(201,201,201,0.05),0px_2px_2px_rgba(201,201,201,0.09),0px_1px_1px_rgba(201,201,201,0.10)] hover:bg-[#ddecff]">
+          Дэлгэрэнгүй
+        </Button>
+      </Link>
+    </article>
+  )
+}
+
+export function FinishedExamCard(props: {
+  item: FinishedExamItem
+  studentClass: string
+}) {
+  const { item, studentClass } = props
+  const schedule = getStudentSchedule(item.exam, studentClass)
+
+  if (item.kind === "missed") {
+    return (
+      <article className="flex items-center justify-between gap-3 rounded-2xl border border-[#E6F2FF] bg-[#F9FAFB] p-[17px] shadow-[0px_9px_4px_rgba(201,201,201,0.01),0px_5px_3px_rgba(201,201,201,0.05),0px_2px_2px_rgba(201,201,201,0.09),0px_1px_1px_rgba(201,201,201,0.10)]">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <div className="flex h-[60px] w-[60px] items-center justify-center rounded-2xl p-[10px] text-[#EF4444]">
+            <AlertCircle className="h-8 w-8 stroke-[1.7]" />
+          </div>
+          <div className="min-w-0 flex-1 space-y-2">
+            <div className="flex flex-wrap items-center gap-5">
+              <h3 className="text-[18px] font-semibold leading-[22px] text-[#141A1F]">{item.exam.title}</h3>
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-[#FEE2E2] px-[9px] py-1 text-[12px] font-semibold leading-[1.2] text-[#DC2626]">
+                <span className="h-1.5 w-1.5 rounded-full bg-[#DC2626]" />
+                Хоцорсон
+              </span>
+            </div>
+            <div className="flex flex-wrap items-center gap-3 text-[14px] font-medium leading-[17px] text-[#566069]">
+              <span>{formatScheduleLabel(schedule?.date, schedule?.time)}</span>
+              <span>|</span>
+              <span>{item.exam.duration} мин</span>
+              <span>|</span>
+              <span>{item.exam.questions.length} асуулт</span>
+            </div>
+          </div>
+        </div>
+
+        <Button variant="outline" disabled className="h-[38px] min-w-[124px] rounded-xl border-[#FECACA] bg-[#FEF2F2] px-6 text-[12px] font-medium leading-[1.2] text-[#DC2626] opacity-100">
+          Хоцорсон
+        </Button>
+      </article>
+    )
+  }
+
+  const percentage = Math.round((item.result.score / item.result.totalPoints) * 100)
+  const isReportAvailable = isStudentExamReportAvailable(item.exam)
+
+  return (
+    <article className="flex items-center justify-between gap-3 rounded-2xl border border-[#E6F2FF] bg-[#F9FAFB] p-[17px] shadow-[0px_9px_4px_rgba(201,201,201,0.01),0px_5px_3px_rgba(201,201,201,0.05),0px_2px_2px_rgba(201,201,201,0.09),0px_1px_1px_rgba(201,201,201,0.10)]">
+      <div className="w-full max-w-[700px] space-y-[6px]">
+        <div className="flex items-center gap-3">
+          <div className="flex h-[60px] w-[60px] items-center justify-center rounded-2xl p-[10px]">
+            <Image src={getExamIcon(item.exam.title)} alt="" width={40} height={40} unoptimized className="h-10 w-10 object-contain" />
+          </div>
+
+          <div className="min-w-0 flex-1 space-y-2">
+            <div className="flex flex-wrap items-center gap-5">
+              <h3 className="text-[18px] font-semibold leading-[22px] text-[#141A1F]">{item.exam.title}</h3>
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-[#E8F5E9] px-[9px] py-1 text-[12px] font-semibold leading-[1.2] text-[#00C853]">
+                <Check className="h-[14px] w-[14px]" />
+                Дууссан
+              </span>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3 text-[14px] font-medium leading-[17px]">
+              <span className="text-[#566069]">Илгээсэн: {new Date(item.result.submittedAt).toLocaleString("en-US")}</span>
+              <span className="text-[#566069]">|</span>
+              <span className="text-[#007FFF]">{item.result.score}/{item.result.totalPoints} оноо</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-4">
+          <div className="h-[10px] w-[653px] overflow-hidden rounded-full bg-[#E6F2FF] shadow-[0px_9px_4px_rgba(201,201,201,0.01),0px_5px_3px_rgba(201,201,201,0.05),0px_2px_2px_rgba(201,201,201,0.09),0px_1px_1px_rgba(201,201,201,0.10)]">
+            <div className="h-full rounded-full bg-[#007FFF]" style={{ width: `${percentage}%` }} />
+          </div>
+          <span className="w-[31px] text-[14px] font-semibold leading-[17px] text-[#007FFF]">{percentage}%</span>
+        </div>
+      </div>
+
+      <Link href={`/student/reports/${item.result.examId}`}>
+        <Button variant="outline" className="h-[38px] min-w-[124px] rounded-xl border-[#E6F2FF] bg-[#E6F2FF] px-6 text-[12px] font-medium leading-[1.2] text-[#007FFF] shadow-[0px_9px_4px_rgba(201,201,201,0.01),0px_5px_3px_rgba(201,201,201,0.05),0px_2px_2px_rgba(201,201,201,0.09),0px_1px_1px_rgba(201,201,201,0.10)] hover:bg-[#ddecff]">
+          {isReportAvailable ? "Дэлгэрэнгүй" : "Тайлан түгжээтэй"}
+        </Button>
+      </Link>
+    </article>
+  )
+}

--- a/frontend/src/components/student/student-exams-page-controls.tsx
+++ b/frontend/src/components/student/student-exams-page-controls.tsx
@@ -1,0 +1,33 @@
+type SegmentedTabProps = {
+  active: boolean
+  count: number
+  label: string
+  onClick: () => void
+}
+
+export function SegmentedTab(props: SegmentedTabProps) {
+  const { active, count, label, onClick } = props
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={[
+        "flex h-8 w-[137px] cursor-pointer items-center justify-between rounded-full px-6 py-1 text-[14px] font-medium leading-5 transition",
+        active
+          ? "bg-[radial-gradient(123.22%_129.67%_at_100.89%_-5.6%,#FFFFFF_0%,#FEFEFF_100%)] text-[#141A1F] shadow-[0px_9px_4px_rgba(201,201,201,0.01),0px_5px_3px_rgba(201,201,201,0.05),0px_2px_2px_rgba(201,201,201,0.09),0px_1px_1px_rgba(201,201,201,0.10)]"
+          : "text-[#F9FAFB]",
+      ].join(" ")}
+    >
+      <span>{label}</span>
+      <span
+        className={[
+          "flex h-6 w-6 items-center justify-center rounded-full text-[12px] font-medium leading-[1.2]",
+          active ? "bg-[#3399FF] text-white" : "bg-white/10 text-[#A4ADB5]",
+        ].join(" ")}
+      >
+        {count}
+      </span>
+    </button>
+  )
+}

--- a/frontend/src/components/student/student-exams-page-utils.ts
+++ b/frontend/src/components/student/student-exams-page-utils.ts
@@ -1,0 +1,33 @@
+import type { Exam, ExamResult } from "@/lib/mock-data"
+import { getLocalDateString } from "@/lib/student-exam-time"
+
+export const FIGMA_ICON_PHYSICS = "https://www.figma.com/api/mcp/asset/4ff94fbd-ead0-4ad6-a08e-0ff33b094601"
+export const FIGMA_ICON_SOCIAL = "https://www.figma.com/api/mcp/asset/7da72c0e-2c2b-4589-9e7a-c5b667159b2d"
+export const FIGMA_ICON_MATH = "https://www.figma.com/api/mcp/asset/343ac7d5-4933-4203-afc0-cca382acf71f"
+export const FIGMA_ICON_CHEMISTRY = "https://www.figma.com/api/mcp/asset/a64413ea-0461-4a8b-a509-ff709c4865e9"
+
+export type FinishedExamItem =
+  | { kind: "result"; exam: Exam; result: ExamResult }
+  | { kind: "missed"; exam: Exam }
+
+export function getStudentSchedule(exam: Exam, studentClass: string) {
+  return exam.scheduledClasses.find((entry) => entry.classId === studentClass)
+}
+
+export function getExamCategory(exam: Exam) {
+  return exam.title.split(/[-–]/)[0]?.trim() || exam.title
+}
+
+export function getExamIcon(title: string) {
+  const lowerTitle = title.toLowerCase()
+
+  if (lowerTitle.includes("хими")) return FIGMA_ICON_CHEMISTRY
+  if (lowerTitle.includes("нийгмийн")) return FIGMA_ICON_SOCIAL
+  if (lowerTitle.includes("математик")) return FIGMA_ICON_MATH
+  return FIGMA_ICON_PHYSICS
+}
+
+export function formatScheduleLabel(date?: string, time?: string) {
+  if (!date || !time) return "Хуваарь ороогүй"
+  return date === getLocalDateString() ? `Өнөөдөр · ${time}` : `${date} · ${time}`
+}

--- a/frontend/src/hooks/use-student-dashboard-profile.ts
+++ b/frontend/src/hooks/use-student-dashboard-profile.ts
@@ -1,0 +1,127 @@
+"use client"
+
+import { type ChangeEvent, useCallback, useEffect, useState } from "react"
+import { notifyStudentSessionChange } from "@/hooks/use-student-session"
+import { deleteUpload, listUploads, uploadFile } from "@/lib/uploads-api"
+
+const STORAGE_KEYS = {
+  bio: "studentProfileBio",
+} as const
+
+const defaultBio = "Би ирээдүйд Дизайнер болно."
+
+export type StudentProfileState = {
+  name: string
+  bio: string
+  image: string
+  imageUploadId: string
+}
+
+function getAvatarStorageKey(studentId: string) {
+  return `studentProfileImageUploadId:${studentId || "anonymous"}`
+}
+
+function buildAvatarContentUrl(uploadId: string) {
+  return `/api/backend/uploads/${uploadId}/content`
+}
+
+function getStoredProfile(studentId: string, studentName: string): StudentProfileState {
+  if (typeof window === "undefined") {
+    return { name: studentName, bio: defaultBio, image: "", imageUploadId: "" }
+  }
+
+  const imageUploadId = studentId ? localStorage.getItem(getAvatarStorageKey(studentId)) || "" : ""
+
+  return {
+    name: localStorage.getItem("studentName") || studentName,
+    bio: localStorage.getItem(STORAGE_KEYS.bio) || defaultBio,
+    image: imageUploadId ? buildAvatarContentUrl(imageUploadId) : "",
+    imageUploadId,
+  }
+}
+
+export function useStudentDashboardProfile(studentId: string, studentName: string) {
+  const [profile, setProfile] = useState<StudentProfileState>(() => getStoredProfile(studentId, studentName))
+  const [draft, setDraft] = useState<StudentProfileState>(() => getStoredProfile(studentId, studentName))
+  const [isUploadingImage, setIsUploadingImage] = useState(false)
+
+  const persistProfile = useCallback((nextProfile: StudentProfileState) => {
+    localStorage.setItem("studentName", nextProfile.name)
+    localStorage.setItem(STORAGE_KEYS.bio, nextProfile.bio)
+
+    if (studentId && nextProfile.imageUploadId) {
+      localStorage.setItem(getAvatarStorageKey(studentId), nextProfile.imageUploadId)
+    } else if (studentId) {
+      localStorage.removeItem(getAvatarStorageKey(studentId))
+    }
+
+    notifyStudentSessionChange()
+    setProfile(nextProfile)
+  }, [studentId])
+
+  useEffect(() => {
+    const nextProfile = getStoredProfile(studentId, studentName)
+    setProfile(nextProfile)
+    setDraft(nextProfile)
+  }, [studentId, studentName])
+
+  useEffect(() => {
+    if (!studentId) return
+
+    let isMounted = true
+
+    const loadAvatar = async () => {
+      try {
+        const uploads = await listUploads(`student-avatars/${studentId}`)
+        const latestAvatar = uploads[0]
+        if (!isMounted || !latestAvatar) return
+
+        const nextProfile = {
+          ...getStoredProfile(studentId, studentName),
+          image: buildAvatarContentUrl(latestAvatar.id),
+          imageUploadId: latestAvatar.id,
+        }
+
+        persistProfile(nextProfile)
+        setDraft(nextProfile)
+      } catch (error) {
+        console.warn("Failed to load student avatar from R2.", error)
+      }
+    }
+
+    void loadAvatar()
+    return () => {
+      isMounted = false
+    }
+  }, [persistProfile, studentId, studentName])
+
+  const handleImageChange = async (event: ChangeEvent<HTMLInputElement>, saveImmediately = false) => {
+    const file = event.target.files?.[0]
+    event.target.value = ""
+    if (!file || !studentId) return
+
+    setIsUploadingImage(true)
+    try {
+      const nextUpload = await uploadFile({ file, fileName: file.name, folder: `student-avatars/${studentId}` })
+      const nextProfile = { ...draft, image: buildAvatarContentUrl(nextUpload.id), imageUploadId: nextUpload.id }
+
+      setDraft(nextProfile)
+
+      if (profile.imageUploadId && profile.imageUploadId !== nextUpload.id) {
+        try {
+          await deleteUpload(profile.imageUploadId)
+        } catch (error) {
+          console.warn("Failed to delete previous student avatar from R2.", error)
+        }
+      }
+
+      if (saveImmediately) persistProfile(nextProfile)
+    } catch (error) {
+      console.warn("Failed to upload student avatar to R2.", error)
+    } finally {
+      setIsUploadingImage(false)
+    }
+  }
+
+  return { defaultBio, draft, isUploadingImage, persistProfile, profile, setDraft, handleImageChange }
+}

--- a/frontend/src/hooks/use-student-exams-page.ts
+++ b/frontend/src/hooks/use-student-exams-page.ts
@@ -1,0 +1,174 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import {
+  type FinishedExamItem,
+  getExamCategory,
+  getStudentSchedule,
+} from "@/components/student/student-exams-page-utils"
+import { useStudentSession } from "@/hooks/use-student-session"
+import { exams as legacyExams, type Exam, type ExamResult } from "@/lib/mock-data"
+import { getCachedStudentExamResults, loadStudentExamResults } from "@/lib/student-exam-results"
+import { getScheduleEnd } from "@/lib/student-exam-time"
+import { getStudentExams } from "@/lib/student-exams"
+
+export function useStudentExamsPage() {
+  const { studentClass, studentId } = useStudentSession()
+  const [searchQuery, setSearchQuery] = useState("")
+  const [selectedCategory, setSelectedCategory] = useState("all")
+  const [activeTab, setActiveTab] = useState<"all" | "upcoming" | "finished">("all")
+  const [allExams, setAllExams] = useState<Exam[]>(legacyExams)
+  const [allResults, setAllResults] = useState<ExamResult[]>(() => getCachedStudentExamResults())
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const loadExams = async () => {
+      try {
+        const [nextExams, nextResults] = await Promise.all([
+          getStudentExams(),
+          loadStudentExamResults({ studentId }),
+        ])
+        if (!isMounted) return
+        setAllExams(nextExams)
+        setAllResults(nextResults)
+      } catch (error) {
+        if (isMounted) console.warn("Failed to refresh student exams from the backend.", error)
+      } finally {
+        if (isMounted) setIsLoading(false)
+      }
+    }
+
+    void loadExams()
+    return () => {
+      isMounted = false
+    }
+  }, [studentId])
+
+  const myExams = useMemo(
+    () =>
+      allExams.filter((exam) =>
+        exam.scheduledClasses.some((schedule) => schedule.classId === studentClass),
+      ),
+    [allExams, studentClass],
+  )
+
+  const myResults = useMemo(
+    () => allResults.filter((result) => result.studentId === studentId),
+    [allResults, studentId],
+  )
+
+  const completedExamIds = useMemo(
+    () => new Set(myResults.map((result) => result.examId)),
+    [myResults],
+  )
+
+  const scheduledExams = useMemo(
+    () => myExams.filter((exam) => exam.status === "scheduled"),
+    [myExams],
+  )
+
+  const activeScheduledExams = useMemo(
+    () =>
+      scheduledExams.filter((exam) => {
+        if (completedExamIds.has(exam.id)) return false
+        const schedule = getStudentSchedule(exam, studentClass)
+        if (!schedule) return false
+        return getScheduleEnd(schedule.date, schedule.time, exam.duration) > new Date()
+      }),
+    [completedExamIds, scheduledExams, studentClass],
+  )
+
+  const missedExams = useMemo(
+    () =>
+      scheduledExams.filter((exam) => {
+        if (completedExamIds.has(exam.id)) return false
+        const schedule = getStudentSchedule(exam, studentClass)
+        if (!schedule) return false
+        return getScheduleEnd(schedule.date, schedule.time, exam.duration) <= new Date()
+      }),
+    [completedExamIds, scheduledExams, studentClass],
+  )
+
+  const categoryOptions = useMemo(() => {
+    const nextCategories = new Set<string>()
+    myExams.forEach((exam) => nextCategories.add(getExamCategory(exam)))
+    return ["all", ...Array.from(nextCategories)]
+  }, [myExams])
+
+  const normalizedQuery = searchQuery.trim().toLowerCase()
+  const matchesFilters = useCallback(
+    (exam: Exam) => {
+      const matchesSearch =
+        normalizedQuery.length === 0 ||
+        exam.title.toLowerCase().includes(normalizedQuery) ||
+        getExamCategory(exam).toLowerCase().includes(normalizedQuery)
+      const matchesCategory =
+        selectedCategory === "all" || getExamCategory(exam) === selectedCategory
+      return matchesSearch && matchesCategory
+    },
+    [normalizedQuery, selectedCategory],
+  )
+
+  const filteredUpcomingExams = useMemo(
+    () => activeScheduledExams.filter(matchesFilters),
+    [activeScheduledExams, matchesFilters],
+  )
+
+  const finishedItems = useMemo<FinishedExamItem[]>(
+    () =>
+      [
+        ...myResults
+          .map((result) => {
+            const exam = allExams.find((entry) => entry.id === result.examId)
+            return exam ? ({ kind: "result", exam, result } as const) : null
+          })
+          .filter(
+            (
+              entry,
+            ): entry is {
+              kind: "result"
+              exam: Exam
+              result: ExamResult
+            } => Boolean(entry),
+          ),
+        ...missedExams.map((exam) => ({ kind: "missed", exam } as const)),
+      ]
+        .filter((item) => matchesFilters(item.exam))
+        .sort((left, right) => {
+          const leftTime =
+            left.kind === "result"
+              ? new Date(left.result.submittedAt).getTime()
+              : getScheduleEnd(
+                  getStudentSchedule(left.exam, studentClass)?.date || "",
+                  getStudentSchedule(left.exam, studentClass)?.time || "00:00",
+                  left.exam.duration,
+                ).getTime()
+          const rightTime =
+            right.kind === "result"
+              ? new Date(right.result.submittedAt).getTime()
+              : getScheduleEnd(
+                  getStudentSchedule(right.exam, studentClass)?.date || "",
+                  getStudentSchedule(right.exam, studentClass)?.time || "00:00",
+                  right.exam.duration,
+                ).getTime()
+          return rightTime - leftTime
+        }),
+    [allExams, matchesFilters, missedExams, myResults, studentClass],
+  )
+
+  return {
+    activeTab,
+    categoryOptions,
+    filteredUpcomingExams,
+    finishedItems,
+    isLoading,
+    searchQuery,
+    selectedCategory,
+    setActiveTab,
+    setSearchQuery,
+    setSelectedCategory,
+    studentClass,
+  }
+}

--- a/scripts/check_backend_health.ps1
+++ b/scripts/check_backend_health.ps1
@@ -1,0 +1,69 @@
+$ErrorActionPreference = "Stop"
+
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$BaseUrl
+)
+
+function Normalize-BaseUrl {
+  param([string]$Value)
+
+  $trimmed = $Value.Trim()
+  if (-not $trimmed) {
+    throw "BaseUrl cannot be empty."
+  }
+
+  return $trimmed.TrimEnd("/")
+}
+
+$normalizedBaseUrl = Normalize-BaseUrl -Value $BaseUrl
+$healthUrl = "$normalizedBaseUrl/api/health"
+
+Write-Host "Checking backend health at $healthUrl"
+
+try {
+  $response = Invoke-RestMethod -Uri $healthUrl -Method Get -TimeoutSec 20
+} catch {
+  throw "Failed to reach $healthUrl. $($_.Exception.Message)"
+}
+
+$uploadMetadataPersistence = $response.uploadMetadataPersistence
+$storageConfigured = $response.storageConfigured
+$databaseConfigured = $response.databaseConfigured
+
+Write-Host ""
+Write-Host "Health response summary"
+Write-Host "status: $($response.status)"
+Write-Host "service: $($response.service)"
+Write-Host "databaseConfigured: $databaseConfigured"
+Write-Host "uploadMetadataPersistence: $uploadMetadataPersistence"
+Write-Host "storageConfigured: $storageConfigured"
+
+$errors = @()
+
+if ($response.status -ne "ok") {
+  $errors += "Expected status 'ok' but received '$($response.status)'."
+}
+
+if (-not $databaseConfigured) {
+  $errors += "databaseConfigured is false. Production is not using shared D1 metadata."
+}
+
+if ($uploadMetadataPersistence -ne "d1") {
+  $errors += "uploadMetadataPersistence is '$uploadMetadataPersistence' instead of 'd1'."
+}
+
+if (-not $storageConfigured) {
+  $errors += "storageConfigured is false. R2 is not fully configured."
+}
+
+if ($errors.Count -gt 0) {
+  Write-Host ""
+  Write-Host "Result: FAILED" -ForegroundColor Red
+  $errors | ForEach-Object { Write-Host "- $_" -ForegroundColor Red }
+  exit 1
+}
+
+Write-Host ""
+Write-Host "Result: OK" -ForegroundColor Green
+Write-Host "Production is reporting shared upload metadata via D1 and R2 storage is configured."


### PR DESCRIPTION
- Reworked the student exams page to follow the connected Figma layouts more closely, including the search bar, subject filter, segmented tabs, and card spacing.
- Wired the Бүгд, Удахгүй, and Дууссан tabs to actually filter the visible exam sections.
- Fixed exam categorization so completed exams no longer appear in upcoming exams.
- Moved submitted exams into the finished section and kept report access there.
- Added a clear missed-exam state for late/unsubmitted past exams.
- Updated the page to use the dedicated Figma icon asset set for exam cards.
- Improved the exam detail loading flow so clicking Үзэх shows a loading state instead of flashing Шалгалт олдосонгүй.
- Added site-wide pointer cursor styling for interactive elements.
- Added student avatar upload support backed by the existing backend uploads flow and R2 storage.
- Verified production backend health requirements for shared avatar visibility and added a helper script for backend health checks.
